### PR TITLE
Don't fully catch the first render.

### DIFF
--- a/src/BaseLoginForm.jsx
+++ b/src/BaseLoginForm.jsx
@@ -46,15 +46,15 @@ class BaseLoginForm extends Component {
                 this.onTokenChange(token);
                 return auth.refreshToken();
             })
-            .then(() => {
-                onChange({
-                    isTokenValid: true,
-                    requestState: SuccessState()
-                });
-            })
-            .catch(err => {
-                onChange('requestState')(ErrorState());
-            });
+            .then(
+                () => {
+                    onChange({
+                        isTokenValid: true,
+                        requestState: SuccessState()
+                    });
+                },
+                () => onChange('requestState')(ErrorState())
+            );
     }
     onLogin(event: Event) {
         const {


### PR DESCRIPTION
Still catches errros in the refresh token. But doesn't swallow up
errors thrown in the initial render cycle.