### PR TITLE
Add username props and login links

### DIFF
--- a/src/web/components/ForgotPasswordForm.jsx
+++ b/src/web/components/ForgotPasswordForm.jsx
@@ -1,34 +1,67 @@
 /* @flow */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import BaseForgotPasswordForm from '../../BaseForgotPasswordForm';
 import Input from 'stampy/lib/input/input/Input';
 import Button from 'stampy/lib/component/button/Button';
 import Label from 'stampy/lib/component/field/Label';
 import Messages from './Messages';
+import {UsernamePropTypes, UsernameDefaultProps} from './Props';
 import auth from '../auth';
 
 var LoadingComponent = () => <div>Loading...</div>;
 
 function RequestComponent(props: Object): React.Element {
-    const {onChange, onRequest, errors, username} = props;
+    const {
+        errors,
+        loginPath,
+        onChange,
+        onRequest,
+        username,
+        usernameProps
+    } = props;
 
     return <div>
         <form className="ReactCognitoForm" onSubmit={onRequest} method="post">
-            <Label spruceName="ReactCognitoFormLabel">Email</Label>
-            <Input spruceName="ReactCognitoFormInput" modifier="text" type="email" name="email" placeholder="Email" value={username} onChange={onChange('username')}/>
+            <Label spruceName="ReactCognitoFormLabel">{usernameProps.label}</Label>
+            <Input
+                spruceName="ReactCognitoFormInput"
+                modifier="text"
+                value={username}
+                onChange={onChange('username')}
+                inputProps={{autoComplete: 'username'}}
+                {...usernameProps}
+            />
             <Button spruceName="ReactCognitoFormButton" type="submit">Reset Password</Button>
         </form>
         <Messages errors={errors} />
+        <div>
+            {loginPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-login" href={loginPath}>Back to login</a>}
+        </div>
     </div>;
 }
 
+RequestComponent.propTypes = {
+    errors: PropTypes.array,
+    loginPath: PropTypes.string,
+    onChange: PropTypes.func,
+    onRequest: PropTypes.func,
+    username: PropTypes.string,
+    usernameProps: UsernamePropTypes
+};
+
+RequestComponent.defaultProps = {
+    usernameProps: UsernameDefaultProps
+};
+
 function ConfirmComponent(props: Object): React.Element {
     const {
+        confirmationCode,
+        errors,
+        loginPath,
         onChange,
         onConfirm,
-        errors,
-        confirmationCode,
         password
     } = props;
 
@@ -59,6 +92,9 @@ function ConfirmComponent(props: Object): React.Element {
             <Button spruceName="ReactCognitoFormButton" type="submit">Change Password</Button>
         </form>
         <Messages errors={errors} />
+        <div>
+            {loginPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-login" href={loginPath}>Back to login</a>}
+        </div>
     </div>;
 }
 

--- a/src/web/components/LoginForm.jsx
+++ b/src/web/components/LoginForm.jsx
@@ -1,10 +1,12 @@
 /* @flow */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import BaseLoginForm from '../../BaseLoginForm';
 import Input from 'stampy/lib/input/input/Input';
 import Button from 'stampy/lib/component/button/Button';
 import Label from 'stampy/lib/component/field/Label';
+import {UsernamePropTypes, UsernameDefaultProps} from './Props';
 
 import VerificationForm from './VerificationForm';
 import Messages from './Messages';
@@ -15,34 +17,70 @@ var WrappingComponent = (props) => <div>{props.children}</div>;
 
 
 function LoginComponent(props: Object): React.Element {
-    const {forgotPasswordPath, signUpPath, onChange, onLogin, errors, messages, username, password} = props;
+    const {
+        errors,
+        forgotPasswordPath,
+        messages,
+        onChange,
+        onLogin,
+        password,
+        signUpPath,
+        username,
+        usernameProps
+    } = props;
 
-    const usernameInputProps = {
-        name: 'email',
-        autoComplete: 'username'
-    }
-
-    const passwordInputProps = {
-        name: 'password',
-        autoComplete: 'password'
+    const passwordProps = {
+        name: "password",
+        autoComplete: "password",
+        type: "password",
+        placeholder: "Password"
     }
 
     return <div>
         <form className="ReactCognitoForm" onSubmit={onLogin} method="post">
-            <Label spruceName="ReactCognitoFormLabel">Email</Label>
-            <Input spruceName="ReactCognitoFormInput" modifier="text" type="email" placeholder="Email" value={username} onChange={onChange('username')} inputProps={usernameInputProps} />
+            <Label spruceName="ReactCognitoFormLabel">{usernameProps.label}</Label>
+            <Input
+                spruceName="ReactCognitoFormInput"
+                modifier="text"
+                value={username}
+                onChange={onChange('username')}
+                inputProps={{autoComplete: 'username'}}
+                {...usernameProps}
+            />
             <Label spruceName="ReactCognitoFormLabel">Password</Label>
-            <Input spruceName="ReactCognitoFormInput" modifier="text" type="password" placeholder="Password" value={password} onChange={onChange('password')} inputProps={passwordInputProps} />
+            <Input
+                spruceName="ReactCognitoFormInput"
+                modifier="text"
+                value={password}
+                onChange={onChange('password')}
+                inputProps={{autoComplete: 'password'}}
+                {...passwordProps}
+            />
             <Button spruceName="ReactCognitoFormButton" type="submit">Sign In</Button>
         </form>
         <Messages errors={errors} messages={messages} />
-
         <div>
-            {signUpPath ? <a className="ReactCognitoFormLink ReactCognitoFormLink-signup" href={signUpPath}>Create an account</a> : null}
-            {forgotPasswordPath ? <a className="ReactCognitoFormLink ReactCognitoFormLink-forgotPassword" href={forgotPasswordPath}>Forgot your password?</a> : null}
+            {signUpPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-signup" href={signUpPath}>Create an account</a>}
+            {forgotPasswordPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-forgotPassword" href={forgotPasswordPath}>Forgot your password?</a>}
         </div>
     </div>;
 }
+
+LoginComponent.propTypes = {
+    errors: PropTypes.array,
+    forgotPasswordPath: PropTypes.string,
+    messages: PropTypes.array,
+    onChange: PropTypes.func,
+    onLogin: PropTypes.func,
+    password: PropTypes.string,
+    signUpPath: PropTypes.string,
+    username: PropTypes.string,
+    usernameProps: UsernamePropTypes
+};
+
+LoginComponent.defaultProps = {
+    usernameProps: UsernameDefaultProps
+};
 
 export default class LoginFormWrapper extends React.Component {
     render(): React.Element<any> {

--- a/src/web/components/Props.js
+++ b/src/web/components/Props.js
@@ -1,0 +1,16 @@
+/* @flow */
+import PropTypes from 'prop-types';
+
+export const UsernamePropTypes = PropTypes.shape({
+    label: PropTypes.string,
+    type: PropTypes.string,
+    name: PropTypes.string,
+    placeholder: PropTypes.string
+});
+
+export const UsernameDefaultProps = {
+    label: "Email",
+    type: "email",
+    name: "email",
+    placeholder: "Email"
+};

--- a/src/web/components/SignUpForm.jsx
+++ b/src/web/components/SignUpForm.jsx
@@ -33,14 +33,13 @@ function RenderField(props: Object): React.Element<any> {
 
 function SignUpComponent(props: Object): React.Element {
     const {
-        isSaving,
-        onSubmit,
-        onChange,
         errors,
-        fields
+        fields,
+        isSaving,
+        loginPath,
+        onChange,
+        onSubmit
     } = props;
-
-
 
     const fieldItems = fields
         .map((field: Object) => {
@@ -70,6 +69,9 @@ function SignUpComponent(props: Object): React.Element {
             {isSaving ? null : <Button spruceName="ReactCognitoFormButton" type="submit">Sign Up</Button>}
         </form>
         <Messages errors={errors} />
+        <div>
+            {loginPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-login" href={loginPath}>Already have an account?</a>}
+        </div>
     </div>;
 }
 
@@ -77,6 +79,7 @@ SignUpComponent.propTypes = {
     errors: PropTypes.array,
     fields: PropTypes.array,
     isSaving: PropTypes.bool,
+    loginPath: PropTypes.string,
     onChange: PropTypes.func,
     onSubmit: PropTypes.func
 }


### PR DESCRIPTION
- Add username props, with default props of email so usage doesn't have to be changed on existing projects.
- Add `loginPath` prop / "Back to login" and "Already have an account?" links. Defaults to not show these unless `loginPath` is provided so usage doesn't have to be changed on existing projects.