### PR TITLE
Export forgot password forms

### DIFF
--- a/src/web/components/ForgotPasswordConfirmForm.jsx
+++ b/src/web/components/ForgotPasswordConfirmForm.jsx
@@ -1,0 +1,52 @@
+/* @flow */
+
+import React from 'react';
+import Input from 'stampy/lib/input/input/Input';
+import Button from 'stampy/lib/component/button/Button';
+import Label from 'stampy/lib/component/field/Label';
+import Messages from './Messages';
+
+export default function ForgotPasswordConfirmForm(props: Object): React.Element {
+    const {
+        confirmationCode,
+        confirmIntro,
+        errors,
+        loginPath,
+        onChange,
+        onConfirm,
+        password
+    } = props;
+
+    return <div>
+        {confirmIntro}
+        <form autoComplete="off" className="ReactCognitoForm" onSubmit={onConfirm} method="post">
+            <Label spruceName="ReactCognitoFormLabel">Verification Code</Label>
+            <Input
+                spruceName="ReactCognitoFormInput"
+                modifier="text"
+                type="text"
+                name="confirmationCode"
+                placeholder="e.g. 12345678"
+                value={confirmationCode}
+                onChange={onChange('confirmationCode')}
+                inputProps={{autocomplete: "off"}}
+            />
+            <Label spruceName="ReactCognitoFormLabel">New Password</Label>
+            <Input
+                spruceName="ReactCognitoFormInput"
+                modifier="text"
+                type="password"
+                name="password"
+                placeholder="Password"
+                value={password}
+                onChange={onChange('password')}
+                inputProps={{autocomplete: "off"}}
+            />
+            <Button spruceName="ReactCognitoFormButton" type="submit">Change Password</Button>
+        </form>
+        <Messages errors={errors} />
+        <div>
+            {loginPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-login" href={loginPath}>Back to login</a>}
+        </div>
+    </div>;
+}

--- a/src/web/components/ForgotPasswordForm.jsx
+++ b/src/web/components/ForgotPasswordForm.jsx
@@ -1,109 +1,19 @@
 /* @flow */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import BaseForgotPasswordForm from '../../BaseForgotPasswordForm';
-import Input from 'stampy/lib/input/input/Input';
-import Button from 'stampy/lib/component/button/Button';
-import Label from 'stampy/lib/component/field/Label';
-import Messages from './Messages';
-import {UsernamePropTypes, UsernameDefaultProps} from './Props';
+import ForgotPasswordRequestForm from './ForgotPasswordRequestForm';
+import ForgotPasswordConfirmForm from './ForgotPasswordConfirmForm';
 import auth from '../auth';
 
 var LoadingComponent = () => <div>Loading...</div>;
-
-function RequestComponent(props: Object): React.Element {
-    const {
-        errors,
-        loginPath,
-        onChange,
-        onRequest,
-        username,
-        usernameProps
-    } = props;
-
-    return <div>
-        <form className="ReactCognitoForm" onSubmit={onRequest} method="post">
-            <Label spruceName="ReactCognitoFormLabel">{usernameProps.label}</Label>
-            <Input
-                spruceName="ReactCognitoFormInput"
-                modifier="text"
-                value={username}
-                onChange={onChange('username')}
-                inputProps={{autoComplete: 'username'}}
-                {...usernameProps}
-            />
-            <Button spruceName="ReactCognitoFormButton" type="submit">Reset Password</Button>
-        </form>
-        <Messages errors={errors} />
-        <div>
-            {loginPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-login" href={loginPath}>Back to login</a>}
-        </div>
-    </div>;
-}
-
-RequestComponent.propTypes = {
-    errors: PropTypes.array,
-    loginPath: PropTypes.string,
-    onChange: PropTypes.func,
-    onRequest: PropTypes.func,
-    username: PropTypes.string,
-    usernameProps: UsernamePropTypes
-};
-
-RequestComponent.defaultProps = {
-    usernameProps: UsernameDefaultProps
-};
-
-function ConfirmComponent(props: Object): React.Element {
-    const {
-        confirmationCode,
-        errors,
-        loginPath,
-        onChange,
-        onConfirm,
-        password
-    } = props;
-
-    return <div>
-        <form autoComplete="off" className="ReactCognitoForm" onSubmit={onConfirm} method="post">
-            <Label spruceName="ReactCognitoFormLabel">Verification Code</Label>
-            <Input
-                spruceName="ReactCognitoFormInput"
-                modifier="text"
-                type="text"
-                name="confirmationCode"
-                placeholder="e.g. 12345678"
-                value={confirmationCode}
-                onChange={onChange('confirmationCode')}
-                inputProps={{autocomplete: "off"}}
-            />
-            <Label spruceName="ReactCognitoFormLabel">New Password</Label>
-            <Input
-                spruceName="ReactCognitoFormInput"
-                modifier="text"
-                type="password"
-                name="password"
-                placeholder="Password"
-                value={password}
-                onChange={onChange('password')}
-                inputProps={{autocomplete: "off"}}
-            />
-            <Button spruceName="ReactCognitoFormButton" type="submit">Change Password</Button>
-        </form>
-        <Messages errors={errors} />
-        <div>
-            {loginPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-login" href={loginPath}>Back to login</a>}
-        </div>
-    </div>;
-}
 
 export default class LoginFormWrapper extends React.Component {
     render(): React.Element {
         return <BaseForgotPasswordForm
             auth={auth}
-            RequestComponent={RequestComponent}
-            ConfirmComponent={ConfirmComponent}
+            RequestComponent={ForgotPasswordRequestForm}
+            ConfirmComponent={ForgotPasswordConfirmForm}
             LoadingComponent={LoadingComponent}
             {...this.props}
         />;

--- a/src/web/components/ForgotPasswordRequestForm.jsx
+++ b/src/web/components/ForgotPasswordRequestForm.jsx
@@ -1,0 +1,51 @@
+/* @flow */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Input from 'stampy/lib/input/input/Input';
+import Button from 'stampy/lib/component/button/Button';
+import Label from 'stampy/lib/component/field/Label';
+import Messages from './Messages';
+import {UsernamePropTypes, UsernameDefaultProps} from './Props';
+export default function ForgotPasswordRequestForm(props: Object): React.Element {
+    const {
+        errors,
+        loginPath,
+        onChange,
+        onRequest,
+        username,
+        usernameProps
+    } = props;
+
+    return <div>
+        <form className="ReactCognitoForm" onSubmit={onRequest} method="post">
+            <Label spruceName="ReactCognitoFormLabel">{usernameProps.label}</Label>
+            <Input
+                spruceName="ReactCognitoFormInput"
+                modifier="text"
+                value={username}
+                onChange={onChange('username')}
+                inputProps={{autoComplete: 'username'}}
+                {...usernameProps}
+            />
+            <Button spruceName="ReactCognitoFormButton" type="submit">Reset Password</Button>
+        </form>
+        <Messages errors={errors} />
+        <div>
+            {loginPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-login" href={loginPath}>Back to login</a>}
+        </div>
+    </div>;
+}
+
+ForgotPasswordRequestForm.propTypes = {
+    errors: PropTypes.array,
+    loginPath: PropTypes.string,
+    onChange: PropTypes.func,
+    onRequest: PropTypes.func,
+    username: PropTypes.string,
+    usernameProps: UsernamePropTypes
+};
+
+ForgotPasswordRequestForm.defaultProps = {
+    usernameProps: UsernameDefaultProps
+};

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -2,5 +2,7 @@
 export {default as LoginForm} from './components/LoginForm';
 export {default as SignUpForm} from './components/SignUpForm';
 export {default as ForgotPasswordForm} from './components/ForgotPasswordForm';
+export {default as ForgotPasswordRequestForm} from './components/ForgotPasswordRequestForm';
+export {default as ForgotPasswordConfirmForm} from './components/ForgotPasswordConfirmForm';
 export {default as auth} from './auth';
 


### PR DESCRIPTION
Mainly so you can do view-specific additional text like.

```
function ForgotPasswordRequest(props: Object): Element<*> {
    return <Box>
        <Text element="p" modifier="marginKilo">If you've forgotten your password, type your BP Number below. We'll send you an email to make sure it's you.</Text>
        <ForgotPasswordRequestForm {...props} />
    </Box>;
}

function ForgotPasswordConfirm(props: Object): Element<*> {
    return <Box>
        <Text element="p" modifier="marginKilo">We just sent a verification code to your email address. Please enter it below, with your new password.</Text>
        <ForgotPasswordConfirmForm {...props} />
    </Box>;
}


export default class ForgotPasswordPage extends React.Component<Props> {
    render(): Element<*> {
        return <ForgotPasswordForm
            renderForm={CognitoFormLoader(ForgotPasswordFormWrapper)}
            RequestComponent={ForgotPasswordRequest}
            ConfirmComponent={ForgotPasswordConfirm}
            {...FormConfig}
        />;
    }
}

```