### PR TITLE
Export signup components and allow them to be set via props in SignUpForm

### DIFF
--- a/src/web/components/SignUpForm.jsx
+++ b/src/web/components/SignUpForm.jsx
@@ -1,95 +1,19 @@
 /* @flow */
 import React from 'react';
-import PropTypes from 'prop-types';
-import Input from 'stampy/lib/input/input/Input';
-import Label from 'stampy/lib/component/field/Label';
-import Button from 'stampy/lib/component/button/Button';
+import auth from '../auth';
 
 import BaseSignUpForm from '../../BaseSignUpForm';
-import auth from '../auth';
-import Messages from './Messages';
 import VerificationForm from './VerificationForm';
+import SignUpRequestForm from './SignUpRequestForm';
 
 var LoadingComponent = () => <div>Loading...</div>;
 
-function RenderField(props: Object): React.Element<any> {
-    const {
-        name,
-        type,
-        placeholder,
-        onChange,
-        ...rest
-    } = props;
-
-    return <Input
-        name={name}
-        type={type}
-        spruceName="ReactCognitoFormInput"
-        onChange={onChange}
-        placeholder={placeholder}
-        {...rest}
-    />;
-}
-
-function SignUpComponent(props: Object): React.Element {
-    const {
-        errors,
-        fields,
-        isSaving,
-        loginPath,
-        onChange,
-        onSubmit
-    } = props;
-
-    const fieldItems = fields
-        .map((field: Object) => {
-            const {
-                name,
-                title,
-                hint,
-                component: Component = RenderField
-            } = field;
-            return <div key={name} className="ReactCognitoField">
-                <Label spruceName="ReactCognitoFormLabel">
-                    {title}
-                    {hint &&
-                        <Label spruceName="ReactCognitoFormLabel" modifier="sizeMilli">{hint}</Label>
-                    }
-                </Label>
-                <Component
-                    {...field}
-                    onChange={onChange(name)}
-                />
-            </div>
-        });
-
-    return <div>
-        <form onSubmit={onSubmit} method="post">
-            {fieldItems}
-            {isSaving ? null : <Button spruceName="ReactCognitoFormButton" type="submit">Sign Up</Button>}
-        </form>
-        <Messages errors={errors} />
-        <div>
-            {loginPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-login" href={loginPath}>Already have an account?</a>}
-        </div>
-    </div>;
-}
-
-SignUpComponent.propTypes = {
-    errors: PropTypes.array,
-    fields: PropTypes.array,
-    isSaving: PropTypes.bool,
-    loginPath: PropTypes.string,
-    onChange: PropTypes.func,
-    onSubmit: PropTypes.func
-}
-
 export default function SignUpFormWrapper(props: Object): React.Element {
     return <BaseSignUpForm
-        {...props}
         auth={auth}
         LoadingComponent={LoadingComponent}
+        SignUpComponent={SignUpRequestForm}
         VerificationComponent={VerificationForm}
-        SignUpComponent={SignUpComponent}
+        {...props}
     />;
 }

--- a/src/web/components/SignUpRequestForm.jsx
+++ b/src/web/components/SignUpRequestForm.jsx
@@ -1,0 +1,81 @@
+/* @flow */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Input from 'stampy/lib/input/input/Input';
+import Label from 'stampy/lib/component/field/Label';
+import Button from 'stampy/lib/component/button/Button';
+
+import Messages from './Messages';
+
+function RenderField(props: Object): React.Element<any> {
+    const {
+        name,
+        type,
+        placeholder,
+        onChange,
+        ...rest
+    } = props;
+
+    return <Input
+        name={name}
+        type={type}
+        spruceName="ReactCognitoFormInput"
+        onChange={onChange}
+        placeholder={placeholder}
+        {...rest}
+    />;
+}
+
+export default function SignUpRequestForm(props: Object): React.Element {
+    const {
+        errors,
+        fields,
+        isSaving,
+        loginPath,
+        onChange,
+        onSubmit
+    } = props;
+
+    const fieldItems = fields
+        .map((field: Object) => {
+            const {
+                name,
+                title,
+                hint,
+                component: Component = RenderField
+            } = field;
+            return <div key={name} className="ReactCognitoField">
+                <Label spruceName="ReactCognitoFormLabel">
+                    {title}
+                    {hint &&
+                        <Label spruceName="ReactCognitoFormLabel" modifier="sizeMilli">{hint}</Label>
+                    }
+                </Label>
+                <Component
+                    {...field}
+                    onChange={onChange(name)}
+                />
+            </div>
+        });
+
+    return <div>
+        <form onSubmit={onSubmit} method="post">
+            {fieldItems}
+            {isSaving ? null : <Button spruceName="ReactCognitoFormButton" type="submit">Sign Up</Button>}
+        </form>
+        <Messages errors={errors} />
+        <div>
+            {loginPath && <a className="ReactCognitoFormLink ReactCognitoFormLink-login" href={loginPath}>Already have an account?</a>}
+        </div>
+    </div>;
+}
+
+SignUpRequestForm.propTypes = {
+    errors: PropTypes.array,
+    fields: PropTypes.array,
+    isSaving: PropTypes.bool,
+    loginPath: PropTypes.string,
+    onChange: PropTypes.func,
+    onSubmit: PropTypes.func
+}

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -1,8 +1,10 @@
 
-export {default as LoginForm} from './components/LoginForm';
-export {default as SignUpForm} from './components/SignUpForm';
+export {default as auth} from './auth';
 export {default as ForgotPasswordForm} from './components/ForgotPasswordForm';
 export {default as ForgotPasswordRequestForm} from './components/ForgotPasswordRequestForm';
 export {default as ForgotPasswordConfirmForm} from './components/ForgotPasswordConfirmForm';
-export {default as auth} from './auth';
+export {default as LoginForm} from './components/LoginForm';
+export {default as SignUpForm} from './components/SignUpForm';
+export {default as SignUpRequestForm} from './components/SignUpRequestForm';
+export {default as VerificationForm} from './components/VerificationForm';
 


### PR DESCRIPTION
Export the sign up / verification parts of the sign up form separately, and allow them to be passed in as props to `SignUpForm`, so you can add stuff to each part separately like:

```js
import {SignUpForm, VerificationForm} from 'react-cognito-forms';

function VerificationComponent(props: Object): Element<*> {
    return <Box>
        <Text element="p" modifier="marginKilo">We just sent a verification code to your email address. Please enter it below.</Text>
        <VerificationForm {...props} />
    </Box>;
}

export default class SignUpPage extends React.Component<Props> {
    render(): Element<*> {
        return <SignUpForm
            {...FormConfig}
            VerificationComponent={VerificationComponent}
        />;
    }
}
```

The forgot password forms use the same pattern already.